### PR TITLE
Fix Docusaurus docs build warnings and errors

### DIFF
--- a/docs/site/docusaurus.config.ts
+++ b/docs/site/docusaurus.config.ts
@@ -20,6 +20,10 @@ const config: Config = {
           // Prefer a string path to avoid ESM `require` pitfalls
           sidebarPath: './sidebars.ts',
           editUrl: undefined,
+          exclude: [
+            'site/**',
+            '**/node_modules/**',
+          ],
         },
         blog: false,
         theme: { customCss: './src/css/custom.css' },

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -2,7 +2,6 @@
   "name": "sdd-docs",
   "private": true,
   "version": "0.0.1",
-  "type": "module",
   "scripts": {
     "start": "docusaurus start",
     "build": "docusaurus build",


### PR DESCRIPTION
## Summary
- limit the docs plugin's exclude patterns to `site/**` and `**/node_modules/**` so authored content still builds
- switch the docs package back to CommonJS to restore webpack's require.resolveWeak helper during SSR builds

## Testing
- pnpm -C docs/site build

------
https://chatgpt.com/codex/tasks/task_e_68d1c4b7a9c883248ada2af33a4ec6ac