### PR TITLE
chore: add pnpm workspace for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@
 ## Quickstart
 ```bash
 corepack enable
-pnpm i
+pnpm install
 pnpm docs:gen
 pnpm rtm:build
-
-pnpm -C docs/website i
 pnpm docs:serve   # dev server
 # or
 pnpm docs:build   # static build in docs/website/build
 ```
+
+> ℹ️ The repository is configured as a [pnpm workspace](https://pnpm.io/workspaces). Running `pnpm install` at the root installs the Docusaurus app in `docs/website` along with the rest of the tooling, so you no longer need to run a separate install inside the docs folder.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - docs/website
+  - packages/*
+  - apps/*


### PR DESCRIPTION
## Summary
- register the Docusaurus app as part of a pnpm workspace
- streamline the quickstart instructions so a single install sets up the docs tooling

## Testing
- pnpm docs:build

------
https://chatgpt.com/codex/tasks/task_e_68d1d173a20c8324b9abe5fc5dcb1a5e