### PR TITLE
Select latest spec version for docs and RTM

### DIFF
--- a/scripts/rtm/build-rtm.ts
+++ b/scripts/rtm/build-rtm.ts
@@ -4,8 +4,23 @@ import yaml from 'js-yaml';
 
 const root = process.cwd();
 const specsDir = path.join(root,'docs/specs');
-const srsFile = fs.readdirSync(specsDir).find(f=>/^spec\.v[0-9]+\.[0-9]+\.[0-9]+\.yaml$/.test(f));
-if(!srsFile){ console.error('No SRS found'); process.exit(1); }
+const specVersionRegex = /^spec\.v(\d+)\.(\d+)\.(\d+)\.yaml$/;
+const specFiles = fs.readdirSync(specsDir).filter(f=>specVersionRegex.test(f));
+if(!specFiles.length){ console.error('No SRS found'); process.exit(1); }
+const parseVersion = (filename: string) => {
+  const match = filename.match(specVersionRegex);
+  if(!match){ return { major: 0, minor: 0, patch: 0 }; }
+  const [, major, minor, patch] = match;
+  return { major: Number(major), minor: Number(minor), patch: Number(patch) };
+};
+const srsFile = specFiles.sort((a,b)=>{
+  const va = parseVersion(a);
+  const vb = parseVersion(b);
+  if(vb.major !== va.major){ return vb.major - va.major; }
+  if(vb.minor !== va.minor){ return vb.minor - va.minor; }
+  if(vb.patch !== va.patch){ return vb.patch - va.patch; }
+  return 0;
+})[0];
 const srs:any = yaml.load(fs.readFileSync(path.join(specsDir, srsFile),'utf8'));
 const rows = (srs.requirements||[]).map((r:any)=>{
   const acs = (r.acceptance||[]).map((a:any)=>a.id).join(', ');


### PR DESCRIPTION
## Summary
- update spec and RTM generators to choose the highest semantic versioned spec.v*.yaml
- reuse the version parser to ensure generated docs always reference the newest SRS

## Testing
- pnpm docs:gen
- pnpm rtm:build

------
https://chatgpt.com/codex/tasks/task_e_68d2518d3d848324ad1a8d62e46fb4e4