### PR TITLE
Fix docs workflows to use website folder

### DIFF
--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -28,7 +28,7 @@ jobs:
         run: |
           corepack enable
           pnpm i
-          pnpm -C docs/site i
+          pnpm -C docs/website install
 
       - name: Generate Spec/Brief/Plan + RTM
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/site/build
+          path: docs/website/build
 
   deploy:
     environment:

--- a/.github/workflows/spec-trace.yml
+++ b/.github/workflows/spec-trace.yml
@@ -31,7 +31,7 @@ jobs:
         run: pnpm rtm:build
 
       - name: Install Docs deps (Docusaurus)
-        run: pnpm -C docs/site i
+        run: pnpm -C docs/website install
 
       - name: Build Docs (Docusaurus)
         run: pnpm docs:build
@@ -46,7 +46,7 @@ jobs:
           path: |
             docs/specs/generated/**
             docs/rtm.md
-            docs/site/build/**
+            docs/website/build/**
 
       - name: Ensure AGENTS.md is in sync
         run: |


### PR DESCRIPTION
## Summary
- point the deploy_docs workflow at docs/website for dependency installation and artifact upload
- update the spec-trace workflow to install docs dependencies from docs/website and archive the website build output

## Testing
- pnpm install
- pnpm -C docs/website install
- pnpm docs:gen
- pnpm rtm:build
- pnpm docs:build *(fails: existing MDX files contain unexpected character errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d251a223348324aeb6de5ac1e9f783