### PR TITLE
Add Speckit manifest and governance guardrails

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Guard core template metadata
+/template.json            @airnub
+/template.vars.json       @airnub
+/.speckit/**              @airnub
+/.spectral.yaml           @airnub

--- a/.github/workflows/template-protect.yml
+++ b/.github/workflows/template-protect.yml
@@ -1,0 +1,46 @@
+name: Template Metadata Guardrails
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  protect-template-assets:
+    name: Protect template governance files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce template-change label for protected files
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const protectedFiles = [
+              'template.json',
+              'template.vars.json'
+            ];
+            const protectedPrefixes = [
+              '.speckit/'
+            ];
+            const labelRequired = 'template-change';
+            const labels = (context.payload.pull_request?.labels || []).map(label => label.name);
+            const hasLabel = labels.includes(labelRequired);
+
+            const params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100
+            };
+
+            const modified = [];
+            for await (const response of github.paginate.iterator(github.rest.pulls.listFiles, params)) {
+              for (const file of response.data) {
+                const filename = file.filename;
+                if (protectedFiles.includes(filename) || protectedPrefixes.some(prefix => filename.startsWith(prefix))) {
+                  modified.push(filename);
+                }
+              }
+            }
+
+            if (modified.length && !hasLabel) {
+              core.setFailed(`Protected template files modified without required '${labelRequired}' label. Add the label for intentional updates. Offending paths: ${modified.join(', ')}`);
+            }

--- a/.speckit/NOTICE.md
+++ b/.speckit/NOTICE.md
@@ -1,0 +1,1 @@
+This repo ships as a distribution template. Automated agents MUST NOT modify governance files under `.speckit/**` without maintainer approval.

--- a/.speckit/README.md
+++ b/.speckit/README.md
@@ -1,0 +1,10 @@
+# Speckit Governance (Distribution Template)
+
+This repository is published as a **public Speckit template**. Consumers can import it directly by GitHub URL or surface it inside a local catalog entry.
+
+- Remote import: `speckit template use https://github.com/airnub/next-supabase-speckit-template <target-dir>`.
+- Local catalog: copy this repo under `.speckit/templates/app/next-supabase` inside another project.
+
+> Files under `.speckit/**` are **governance only**. The actual template content lives at the repository root. **Do not add implementation files** to `.speckit/**`.
+
+Speckit templates in consumer repos belong under `.speckit/templates/**`. Remote templates like this one may provide `template.json` and `template.vars.json` at the root so the CLI can prompt for variables and run `postInit` commands automatically.

--- a/README.md
+++ b/README.md
@@ -49,3 +49,19 @@ pnpm docs:build   # static build in docs/website/build
 These commands manage the documentation and verification toolchain only. Once you've scaffolded an app, run its scripts with `pnpm --filter apps/<name> <command>` alongside the workflows above.
 
 > ℹ️ The repository is configured as a [pnpm workspace](https://pnpm.io/workspaces). Running `pnpm install` at the root installs the Docusaurus app in `docs/website` along with the rest of the tooling, so you no longer need to run a separate install inside the docs folder.
+
+## Use with Speckit
+
+Local (as a repo template):
+```sh
+speckit template use https://github.com/airnub/next-supabase-speckit-template ./starter
+```
+
+The CLI will prompt from `template.vars.json`, copy files, then run the `postInit` commands from `template.json` (`pnpm install`, `pnpm docs:gen`, `pnpm rtm:build`). You can also drop this repo under another project's `.speckit/templates/app/next-supabase` and it will appear in the picker. See Speckit's README for template manifests, variable prompts, and post-init commands.
+
+## Manual QA (Speckit)
+
+1. `rm -rf /tmp/next-supabase-template && speckit template use https://github.com/airnub/next-supabase-speckit-template /tmp/next-supabase-template`
+2. Confirm the CLI prompts for `REPO_NAME`, `APP_TITLE`, `SUPABASE_URL`, `SUPABASE_ANON_KEY` (from `template.vars.json`).
+3. Verify `postInit` ran: `pnpm docs:gen` and `pnpm rtm:build`.
+4. Open `/tmp/next-supabase-template/docs/specs/...` and see placeholders replaced.

--- a/template.json
+++ b/template.json
@@ -1,0 +1,11 @@
+{
+  "name": "app/next-supabase",
+  "description": "Next.js + Supabase SDD template (Spec, Agent Brief, Orchestration Plan).",
+  "specRoot": "docs/specs",
+  "varsFile": "template.vars.json",
+  "postInit": [
+    "pnpm install",
+    "pnpm docs:gen",
+    "pnpm rtm:build"
+  ]
+}

--- a/template.vars.json
+++ b/template.vars.json
@@ -1,6 +1,8 @@
 {
-  "REPO_NAME": "{{env.REPO_NAME||auto}}",
-  "APP_TITLE": "{{env.APP_TITLE||Humanized from repo}}",
+  "REPO_NAME": { "prompt": "Repository name", "default": "acme/next-supabase" },
+  "APP_TITLE": { "prompt": "App title", "default": "Acme Web" },
+  "SUPABASE_URL": { "prompt": "Supabase URL (https://…)" },
+  "SUPABASE_ANON_KEY": { "prompt": "Supabase anon key" },
   "APP_PREFIX": "APP",
   "VERSION": "0.0.1",
   "ORG_NAME": "{{env.ORG_NAME||auto}}"


### PR DESCRIPTION
## Summary
- add a Speckit template manifest and document the import flow in the README
- update template variables with Speckit prompts and add governance notes under `.speckit/`
- guard template assets via CODEOWNERS and a workflow requiring the `template-change` label

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d52aad93ec8324bf7b6281417619ae